### PR TITLE
you may want to pull this

### DIFF
--- a/colorgccrc.txt
+++ b/colorgccrc.txt
@@ -20,12 +20,14 @@
 # For example, srcColor: bold cyan on_yellow
 #
 
-# Define the paths to the actual location of the various compilers.
+# Only define the paths to the actual location of the various compilers if
+# you need to do something weird.  For normal installs, we'll figure out
+# who to call next automatically.
 # (Currently, colorgcc only understands these: g++ gcc c++ cc)
-g++: /usr/bin/g++
-gcc: /usr/bin/gcc
-c++: /usr/bin/c++
-cc:  /usr/bin/cc
+##g++: /usr/bin/g++
+##gcc: /usr/bin/gcc
+##c++: /usr/bin/c++
+##cc:  /usr/bin/cc
 
 # Don't do color if our terminal type ($TERM) is one of these.
 # (List all terminal types on one line, seperated by whitespace.)
@@ -33,9 +35,6 @@ nocolor: dumb
 
 # Text between ` and ' is usually source code.
 srcColor: bold cyan
-
-# Text between ‘ and ’ is usually a source code identifier.
-identColor: green
 
 # Text other than a warning or error.
 introFileNameColor: reset


### PR DESCRIPTION
merged with gentoo-patches
from there new features:
    modify PATH to find compiler without need to list them
    color gcc Notes
keeping upstream features these where not within gentoo
    indetifier color
    (clean 2 space indetion)
