### PR TITLE
now, ANSIColor is a Perl core module. So don't retrieve it from CPAN.

### DIFF
--- a/README
+++ b/README
@@ -5,8 +5,6 @@ Version: 1.3.2
 A wrapper to colorize the output from compilers whose messages
 match the "gcc" format.
 
-Requires the ANSIColor module from CPAN.
-
 Usage:
 
 In a directory that occurs in your PATH _before_ the directory

--- a/colorgcc.pl
+++ b/colorgcc.pl
@@ -10,8 +10,6 @@
 # A wrapper to colorize the output from compilers whose messages
 # match the "gcc" format.
 #
-# Requires the ANSIColor module from CPAN.
-#
 # Usage:
 #
 # In a directory that occurs in your PATH _before_ the directory


### PR DESCRIPTION
$ corelist Term::ANSIColor
Term::ANSIColor was first released with perl v5.6.0
