### PR TITLE
Minor (config) change to avoid path munging

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,7 @@ Requires the ANSIColor module from CPAN.
 
 Usage:
 
+Option 1)
 In a directory that occurs in your PATH _before_ the directory
 where the compiler lives, create a softlink to colorgcc for
 each compiler you want to colorize:
@@ -20,6 +21,15 @@ each compiler you want to colorize:
 
 That's it. When "g++" is invoked, colorgcc is run instead.
 colorgcc looks at the program name to figure out which compiler to run.
+
+Option 2)
+In a directory in your PATH, create the following links to colorgcc:
+   color-g++ -> colorgcc
+   color-c++ -> colorgcc
+   color-gcc -> colorgcc
+   color-cc  -> colorgcc
+Then override the compiler macros for make, for example:
+   make CXX=color-g++ CC=color-gcc
 
 The default settings can be overridden with ~/.colorgccrc.
 See the comments in the sample .colorgccrc for more information.

--- a/colorgcc.pl
+++ b/colorgcc.pl
@@ -14,6 +14,7 @@
 #
 # Usage:
 #
+# Option 1)
 # In a directory that occurs in your PATH _before_ the directory
 # where the compiler lives, create a softlink to colorgcc for
 # each compiler you want to colorize:
@@ -25,6 +26,15 @@
 #
 # That's it. When "g++" is invoked, colorgcc is run instead.
 # colorgcc looks at the program name to figure out which compiler to run.
+#
+# Option 2)
+# In a directory in your PATH, create the following links to colorgcc:
+#    color-g++ -> colorgcc
+#    color-c++ -> colorgcc
+#    color-gcc -> colorgcc
+#    color-cc  -> colorgcc
+# Then override the compiler macros for make, for example:
+#    make CXX=color-g++ CC=color-gcc
 #
 # The default settings can be overridden with ~/.colorgccrc.
 # See the comments in the sample .colorgccrc for more information.

--- a/colorgccrc.txt
+++ b/colorgccrc.txt
@@ -27,6 +27,13 @@ gcc: /usr/bin/gcc
 c++: /usr/bin/c++
 cc:  /usr/bin/cc
 
+# Define aliases for the usual compilers to allow using colorgcc
+# without path munging.  (E.g. make CXX=color-g++)
+color-g++: /usr/bin/g++
+color-gcc: /usr/bin/gcc
+color-c++: /usr/bin/c++
+color-cc:  /usr/bin/cc
+
 # Don't do color if our terminal type ($TERM) is one of these.
 # (List all terminal types on one line, seperated by whitespace.)
 nocolor: dumb


### PR DESCRIPTION
In the config, define "color-xxx" (e.g. color-g++) that map to the
standard compilers.  This allows one to avoid using PATH tricks to use
colorgcc, and more easily do per-session or per-invocation use.  By
creating links from color-xxx to colorgcc, projects using make can use
the following approach:
  make CXX=color-g++ CC=color-gcc
or
  export CXX=color-g++; export CC=color-gcc
  make
Add note to this effect in the README.
