### PR TITLE
Update to work with  filename:lino:columnno

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 colorgcc
 
-Version: 1.3.2
+Version: 1.4.0
 
 A wrapper to colorize the output from compilers whose messages
 match the "gcc" format.

--- a/colorgcc.pl
+++ b/colorgcc.pl
@@ -243,21 +243,21 @@ $compiler_pid = open3('<&STDIN', \*GCCOUT, '', $compiler, @ARGV);
 while(<GCCOUT>)
 {
   # filename:lineno:columnno: warning/error: message [-flag]
-  if (m/^(.*?):([0-9]+):([0-9]+):(\s+warning|\s+error):(.*?)(\[.*?\])$/)
+  if (m/^(.*?):([0-9]+):([0-9]*:?)(\s+warning|\s+error):(.*?)(\[.*?\])$/)
   {
-    $field1 = $1 || "";
-    $field2 = $2 || "";
-    $field3 = $3 || "";
-    $field4 = $4 || "";
-    $field5 = $5 || "";
-    $field6 = $6 || "";
+    $field1 = $1 || ""; # Filename
+    $field2 = $2 || ""; # Line
+    $field3 = $3 || ""; # Column
+    $field4 = $4 || ""; # warning/error
+    $field5 = $5 || ""; # message
+    $field6 = $6 || ""; # flag
 
     if ($field4 =~ m/\s+warning/)
     {
       # Warning
       print($colors{"warningFileNameColor"}     , "$field1:", color("reset"));
       print($colors{"warningLineNumberColor"}   , "$field2:", color("reset"));
-      print($colors{"warningColumnNumberColor"} , "$field3:", color("reset"));
+      print($colors{"warningColumnNumberColor"} , "$field3", color("reset"));
       print($colors{"warningWEColor"}           , "$field4:", color("reset"));
       srcscan($field5, $colors{"warningMessageColor"});
       print($colors{"warningFlagColor"}         , "$field6", color("reset"));
@@ -267,7 +267,7 @@ while(<GCCOUT>)
       # Error
       print($colors{"errorFileNameColor"}     , "$field1:", color("reset"));
       print($colors{"errorLineNumberColor"}   , "$field2:", color("reset"));
-      print($colors{"errorColumnNumberColor"} , "$field3:", color("reset"));
+      print($colors{"errorColumnNumberColor"} , "$field3", color("reset"));
       print($colors{"errorWEColor"}           , "$field4:", color("reset"));
       srcscan($field5, $colors{"errorMessageColor"});
       print($colors{"errorFlagColor"}         , "$field6", color("reset"));

--- a/colorgccrc.txt
+++ b/colorgccrc.txt
@@ -49,20 +49,21 @@ introFileNameColor: reset
 introMessageColor:  blue
 
 # Warnings and errors both have similar formats:
-#    filename:999:Message
+#    filename:line:column: warning/error: Message [flag]
 # Each field may be assigned a different color.
 
 # Warnings
 warningFileNameColor: reset
-warningNumberColor:   white
+warningLineNumberColor:   white
+warningColumnNumberColor:   white
+warningWEColor:  bold yellow
 warningMessageColor:  yellow
+warningFlagColor:  reset
 
 # Errors
 errorFileNameColor: reset
-errorNumberColor:   white
-errorMessageColor:  bold red
-
-# Notes
-noteFileNameColor: reset
-noteNumberColor:   white
-noteMessageColor:  green
+errorLineNumberColor:   white
+errorColumnNumberColor:   white
+errorWEColor:  bold red
+errorMessageColor:  red
+errorFlagColor:  reset


### PR DESCRIPTION
In new gcc versions the column number is also printed.

I modified the script to understand this format.
Now it is compatible with both
filename:lineno:columnno:...
and
filename:lineno:...

Furthermore I added more fine grained colorization properties.

The version change to 1.4.0 is because the configuration variables changed.
