### PR TITLE
Define path compilers through env variables

### DIFF
--- a/colorgcc.pl
+++ b/colorgcc.pl
@@ -160,6 +160,14 @@ sub loadPreferences
   close(PREFS);
 }
 
+sub loadEnvPreferences
+{
+    $compilerPaths{"gcc"} = $ENV{'COLORGCC_GCC'} if defined $ENV{'COLORGCC_GCC'};
+    $compilerPaths{"g++"} = $ENV{'COLORGCC_GCXX'} if defined $ENV{'COLORGCC_GCXX'};
+    $compilerPaths{"cc"} = $ENV{'COLORGCC_CC'} if defined $ENV{'COLORGCC_CC'};
+    $compilerPaths{"c++"} = $ENV{'COLORGCC_CXX'} if defined $ENV{'COLORGCC_CXX'};
+}
+
 sub srcscan
 {
   # Usage: srcscan($text, $normalColor)
@@ -203,6 +211,8 @@ if (-f $configFile)
 {
   loadPreferences($configFile);
 }
+
+loadEnvPreferences();
 
 # Figure out which compiler to invoke based on our program name.
 $0 =~ m%.*/(.*)$%;


### PR DESCRIPTION
I have a $HOME in NFS that I share among different computers, with different compilers/paths. So setting the compiler in the colorgccrc file is not an option, because the paths can change from system to system.

And sometimes I need to use a very specific compiler in just a specific moment, so changing the colorgccrc is a bit of nuisance.

Thus I'm following the same approach as ccache do to define different compilers, and adding an option to allow to define the compiler to use through environmental variables. Thus, if some of them are defined it will overwrite the compiler defined in the colorgccrc file.

The variables allowed are:

 COLORGCC_GCC=<path to gcc compiler>
 COLORGCC_GCXX=<path to g++ compiler>
 COLORGCC_CC=<path to cc compiler>
 COLORGCC_CXX=<path to c++ compiler>
